### PR TITLE
Fixing typo

### DIFF
--- a/EGODatabase.m
+++ b/EGODatabase.m
@@ -179,7 +179,7 @@ valistArray;\
 	
 	
 	if (![self bindStatement:statement toParameters:parameters]) {
-		EGODBDebugLog(@"[EGODatabase] Invalid bind cound for number of arguments.");
+		EGODBDebugLog(@"[EGODatabase] Invalid bind count for number of arguments.");
 		sqlite3_finalize(statement);
 		EGODBLockLog(@"%@ released lock", [sql md5]);
 		[executeLock unlock];
@@ -250,7 +250,7 @@ valistArray;\
 	}
 	
 	if (![self bindStatement:statement toParameters:parameters]) {
-		EGODBDebugLog(@"[EGODatabase] Invalid bind cound for number of arguments.");
+		EGODBDebugLog(@"[EGODatabase] Invalid bind count for number of arguments.");
 		sqlite3_finalize(statement);
 		EGODBLockLog(@"%@ released lock", [sql md5]);
 		[executeLock unlock];


### PR DESCRIPTION
Fixing typo in debug log message that is displayed when the user has the improper number of arguments bound to a given query.
