### PR TITLE
NSString no longer responds to longValue

### DIFF
--- a/Classes/EGODatabaseRow.h
+++ b/Classes/EGODatabaseRow.h
@@ -35,6 +35,9 @@
 - (long)longForColumn:(NSString*)name;
 - (long)longForColumnAtIndex:(NSUInteger)index;
 
+- (long long)longLongForColumn:(NSString*)name;
+- (long long)longLongForColumnAtIndex:(NSUInteger)index;
+
 - (BOOL)boolForColumn:(NSString*)name;
 - (BOOL)boolForColumnAtIndex:(NSUInteger)index;
 

--- a/Classes/EGODatabaseRow.m
+++ b/Classes/EGODatabaseRow.m
@@ -61,17 +61,25 @@
 }
 
 - (long)longForColumn:(NSString*)column {
+    return (long)[self longLongForColumn:column];
+}
+
+- (long)longForColumnAtIndex:(NSUInteger)index {
+    return (long)[self longLongForColumnAtIndex:index];
+}
+
+- (long long)longLongForColumn:(NSString*)column {
     NSUInteger index = [self indexForName:column];
 	
 	if(index == NSNotFound) {
 		return 0;
     } else {
-		return [[self.data objectAtIndex:index] longValue];
+		return [[self.data objectAtIndex:index] longLongValue];
 	}
 }
 
-- (long)longForColumnAtIndex:(NSUInteger)index {
-    return [[self.data objectAtIndex:index] longValue];
+- (long long)longLongForColumnAtIndex:(NSUInteger)index {
+    return [[self.data objectAtIndex:index] longLongValue];
 }
 
 - (BOOL)boolForColumn:(NSString*)column {


### PR DESCRIPTION
In `EGODatabaseRow` class
1. Changed `[[self.data objectAtIndex:index] longValue]` to `[[self.data objectAtIndex:index] longLongValue]`, so no more runtime exceptions like `[__NSCFString longValue]: unrecognized selector sent to instance 0x9bf8e10`.
2. Provided new interface and implementation
`- (long long)longLongForColumnAtIndex:(NSUInteger)index`
`- (long long)longLongForColumn:(NSString*)column`